### PR TITLE
Fix: error github workspace,

### DIFF
--- a/.github/workflows/autocommit.yml
+++ b/.github/workflows/autocommit.yml
@@ -13,7 +13,7 @@ jobs:
   auto_commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2      
+      - uses: actions/checkout@v3      
         with:
          persist-credentials: false
          fetch-depth: 0
@@ -45,7 +45,7 @@ jobs:
           git commit -m "${arr[$rand]}"
           
       - name: GitHub Push
-        uses: ad-m/github-push-action@v0.5.0
+        uses: ad-m/github-push-action@master
         with:
           force: true
           directory: "."

--- a/.github/workflows/autocommit.yml
+++ b/.github/workflows/autocommit.yml
@@ -47,6 +47,6 @@ jobs:
       - name: GitHub Push
         uses: ad-m/github-push-action@master
         with:
-          force: true
+          force-with-lease: true
           directory: "."
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix these error on CI, keep the forest green

```
Push to branch ***************
fatal: unsafe repository ('/github/workspace' is owned by someone else)
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```