### PR TITLE
BUGFIX: No such device or address

### DIFF
--- a/.github/workflows/autocommit.yml
+++ b/.github/workflows/autocommit.yml
@@ -45,7 +45,7 @@ jobs:
           git commit -m "${arr[$rand]}"
           
       - name: GitHub Push
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@v0.6.0
         with:
           force_with_lease: true
           directory: "."


### PR DESCRIPTION
fatal: could not read Username for 'https://github.com/': No such device or address
Error: Invalid exit code: 128
    at ChildProcess.<anonymous> (/home/runner/work/_actions/ad-m/github-push-action/master/start.js:2[9](https://github.com/mazipan/auto-commit/actions/runs/3513866248/jobs/5887199253#step:5:10):21)
    at ChildProcess.emit (node:events:390:28)
    at maybeClose (node:internal/child_process:1064:16)
    at Process.ChildProcess._handle.onexit (node:internal/child_process:301:5) {
  code: 128
}
Error: Invalid exit code: 128
    at ChildProcess.<anonymous> (/home/runner/work/_actions/ad-m/github-push-action/master/start.js:29:21)
    at ChildProcess.emit (node:events:390:28)
    at maybeClose (node:internal/child_process:[10](https://github.com/mazipan/auto-commit/actions/runs/3513866248/jobs/5887199253#step:5:11)64:[16](https://github.com/mazipan/auto-commit/actions/runs/3513866248/jobs/5887199253#step:5:17))
    at Process.ChildProcess._handle.onexit (node:internal/child_process:301:5)