### PR TITLE
Node.js 12 actions are deprecated 

### DIFF
--- a/.github/workflows/autocommit.yml
+++ b/.github/workflows/autocommit.yml
@@ -45,7 +45,7 @@ jobs:
           git commit -m "${arr[$rand]}"
           
       - name: GitHub Push
-        uses: ad-m/github-push-action@v0.6.0
+        uses: ad-m/github-push-action@master
         with:
           directory: "."
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description:
Warning:
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: ad-m/github-push-action@v0.6.0. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

### Issue Reference
Reference: https://github.com/ad-m/github-push-action/issues/159